### PR TITLE
fix callouts to render the lesson

### DIFF
--- a/episodes/01-visualizing-ggplot.Rmd
+++ b/episodes/01-visualizing-ggplot.Rmd
@@ -506,7 +506,7 @@ Faceting comes in handy in many scenarios. It can be useful when:
 - your data overlap heavily, obscuring categories
 - you want to show more than 3 variables at once
 - you want to see each category in isolation while allowing for general comparisons between categories
-::::::::::::::::::::::::::::: callout
+:::::::::::::::::::::::::::::::::::::
 
 ## Arranging plots
 
@@ -546,7 +546,7 @@ To combine entire `ggplot` plots together, we will use the package `patchwork`. 
 
 ::::::::::::::::::::::::::::: callout
 It is a good practice not to put `install.packages()` into a script. This is because every time you run that whole script, the package will be reinstalled, which is typically unnecessary. You want to install the package to your computer once, and then load it with `library()` in each script where you need to use it.
-::::::::::::::::::::::::::::: callout
+:::::::::::::::::::::::::::::::::::::
 
 ```{r patchwork}
 library(patchwork)


### PR DESCRIPTION
There were two callout blocks that looked like four callout blocks with no closing tags. This is why https://github.com/MCMaurer/Rewrite-R-ecology-lesson/commit/8937015ea4bcf54511f83ac953f3ea5acac04924 was failing